### PR TITLE
Update NBT API for 1.21.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 
 dependencies {
     compileOnly "io.papermc.paper:paper-api:1.19.4-R0.1-SNAPSHOT"
-    implementation("de.tr7zw:item-nbt-api:2.14.1")
+    implementation("de.tr7zw:item-nbt-api:2.15.2")
 }
 
 shadowJar {

--- a/src/main/java/net/earthmc/xpmanager/util/BottleUtil.java
+++ b/src/main/java/net/earthmc/xpmanager/util/BottleUtil.java
@@ -1,7 +1,6 @@
 package net.earthmc.xpmanager.util;
 
 import de.tr7zw.changeme.nbtapi.NBT;
-import de.tr7zw.changeme.nbtapi.iface.ReadableNBT;
 import net.earthmc.xpmanager.XPManager;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -51,8 +50,9 @@ public class BottleUtil {
         if (container.has(STORE_KEY, PersistentDataType.INTEGER))
             return true;
 
-        ReadableNBT nbti = NBT.readNbt(item);
-        return nbti.hasTag(BOTTLED_EXP_TAG);
+        return NBT.get(item, nbti -> {
+            return nbti.hasTag(BOTTLED_EXP_TAG);
+        });
     }
 
     /**
@@ -63,12 +63,18 @@ public class BottleUtil {
     public static int getXPQuantityFromStoreBottle(ItemStack bottle) {
         PersistentDataContainer container = bottle.getItemMeta().getPersistentDataContainer();
 
-        if (container.has(STORE_KEY))
-            return container.get(STORE_KEY, PersistentDataType.INTEGER);
+        final Integer storedAmount = container.get(STORE_KEY, PersistentDataType.INTEGER);
+        if (storedAmount != null) {
+            return storedAmount;
+        }
 
-        ReadableNBT nbti = NBT.readNbt(bottle);
-        if (nbti.hasTag(BOTTLED_EXP_TAG))
+        final Integer legacyAmount = NBT.get(bottle, nbti -> {
             return nbti.getInteger(BOTTLED_EXP_TAG);
+        });
+
+        if (legacyAmount != null) {
+            return legacyAmount;
+        }
 
         return 0;
     }

--- a/src/main/java/net/earthmc/xpmanager/util/BottleUtil.java
+++ b/src/main/java/net/earthmc/xpmanager/util/BottleUtil.java
@@ -1,6 +1,7 @@
 package net.earthmc.xpmanager.util;
 
-import de.tr7zw.changeme.nbtapi.NBTItem;
+import de.tr7zw.changeme.nbtapi.NBT;
+import de.tr7zw.changeme.nbtapi.iface.ReadableNBT;
 import net.earthmc.xpmanager.XPManager;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -50,7 +51,7 @@ public class BottleUtil {
         if (container.has(STORE_KEY, PersistentDataType.INTEGER))
             return true;
 
-        NBTItem nbti = new NBTItem(item);
+        ReadableNBT nbti = NBT.readNbt(item);
         return nbti.hasTag(BOTTLED_EXP_TAG);
     }
 
@@ -65,7 +66,7 @@ public class BottleUtil {
         if (container.has(STORE_KEY))
             return container.get(STORE_KEY, PersistentDataType.INTEGER);
 
-        NBTItem nbti = new NBTItem(bottle);
+        ReadableNBT nbti = NBT.readNbt(bottle);
         if (nbti.hasTag(BOTTLED_EXP_TAG))
             return nbti.getInteger(BOTTLED_EXP_TAG);
 


### PR DESCRIPTION
https://github.com/tr7zw/Item-NBT-API/releases/tag/2.15.2 was released recently which marks 1.21.8 as compatible, I also replaced the deprecated NBTItem constructor which should also make NBT reading very slightly faster.